### PR TITLE
Nicer exponent formatting

### DIFF
--- a/sonify/sonify.py
+++ b/sonify/sonify.py
@@ -388,6 +388,7 @@ def _spectrogram(
     locator = mdates.AutoDateLocator()
     wf_ax.xaxis.set_major_locator(locator)
     wf_ax.xaxis.set_major_formatter(_UTCDateFormatter(locator, is_local_time))
+    wf_ax.ticklabel_format(axis='y', useMathText=True)  # Format exp. if present
     fig.autofmt_xdate()
 
     # "Crop" x-axis!
@@ -469,6 +470,11 @@ def _spectrogram(
     else:
         pass
     cax.set_position([pos.xmin, ymin, pos.width, height])
+
+    # Move offset text around
+    offset_text = wf_ax.yaxis.get_offset_text()
+    offset_text.set_visible(False)
+    wf_ax.text(0.002, 0.95, offset_text.get_text(), transform=wf_ax.transAxes, ha='left', va='top')
 
     return fig, spec_line, wf_line, time_box, wf_progress
 

--- a/sonify/sonify.py
+++ b/sonify/sonify.py
@@ -474,7 +474,14 @@ def _spectrogram(
     # Move offset text around
     offset_text = wf_ax.yaxis.get_offset_text()
     offset_text.set_visible(False)
-    wf_ax.text(0.002, 0.95, offset_text.get_text(), transform=wf_ax.transAxes, ha='left', va='top')
+    wf_ax.text(
+        0.002,
+        0.95,
+        offset_text.get_text(),
+        transform=wf_ax.transAxes,
+        ha='left',
+        va='top',
+    )
 
     return fig, spec_line, wf_line, time_box, wf_progress
 


### PR DESCRIPTION
This makes the exponent more clear by formatting it more nicely and placing it within the waveform axes (motivated in part by #8).

**Before:**
<img width="1792" alt="1_before" src="https://user-images.githubusercontent.com/38269494/155410747-4e29607e-f5c5-4020-ab65-1aed4040c3be.png">

**After:**
<img width="1792" alt="2_after" src="https://user-images.githubusercontent.com/38269494/155410768-10e848e4-d1b5-4ae8-ae23-d9ced80ed271.png">
