### PR TITLE
Use IRIS routing service to expand data access

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,12 @@
 |docs_badge| |build_badge| |cov_badge| |black_badge| |isort_badge|
 
 *sonify* “squeezes” seismic or infrasound signals into audible frequencies and
-creates animated spectrograms to accompany the audio. Data are pulled from the
-`Incorporated Research Institutions for Seismology (IRIS) Data Management Center
-(DMC) <https://ds.iris.edu/ds/nodes/dmc/>`__.
+creates animated spectrograms to accompany the audio. Data are pulled from any
+of the `FDSN data centers
+<https://service.iris.edu/irisws/fedcatalog/1/datacenters?format=html>`__
+available through the Incorporated Research Institutions for Seismology (IRIS)
+Data Management Center (DMC) `fedcatalog
+<https://service.iris.edu/irisws/fedcatalog/docs/1/help/>`__ web service.
 
 |screenshot|
 


### PR DESCRIPTION
This PR uses IRIS's [fedcatalog](https://service.iris.edu/irisws/fedcatalog/docs/1/help/) via the ObsPy [`RoutingClient`](https://docs.obspy.org/packages/autogen/obspy.clients.fdsn.routing.routing_client.RoutingClient.html) to allow for access to non-IRIS data (example: Raspberry Shake data center).

This closes #10 (PR), which was the original motivation for this PR.

