### PR TITLE
Update version number to be PEP 440 compliant

### DIFF
--- a/.environment.yml
+++ b/.environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - ffmpeg
   - obspy
   - pip
-  - setuptools<58.4.0  # https://github.com/pypa/setuptools/issues/2497
   - tqdm
 # Lines above should be IDENTICAL to environment.yml
   - black

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - ffmpeg
   - obspy
   - pip
-  - setuptools<58.4.0  # https://github.com/pypa/setuptools/issues/2497
   - tqdm
   - pip:
     - --editable .

--- a/sonify/__init__.py
+++ b/sonify/__init__.py
@@ -1,18 +1,21 @@
 import subprocess
 from pathlib import Path
 
-__version__ = subprocess.run(
-    [
-        'git',
-        '-C',
-        Path(__file__).resolve().parent,
-        'rev-parse',
-        '--short=7',
-        'HEAD',
-    ],
-    capture_output=True,
-    text=True,
-).stdout.strip()
+__version__ = (
+    '0+g'  # Makes the version number PEP 440 compliant
+    + subprocess.run(
+        [
+            'git',
+            '-C',
+            Path(__file__).resolve().parent,
+            'rev-parse',
+            '--short=7',  # First 7 characters of the commit hash
+            'HEAD',
+        ],
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+)
 
 del subprocess
 del Path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,4 +15,4 @@ def test_cli_version():
     output = subprocess.run(
         ['sonify', '--version'], capture_output=True, text=True
     ).stdout.strip()
-    assert output == 'sonify, rev. {}'.format(os.environ['GITHUB_SHA'][:7])
+    assert output == 'sonify, rev. 0+g{}'.format(os.environ['GITHUB_SHA'][:7])


### PR DESCRIPTION
[PEP 440](https://peps.python.org/pep-0440/) specifies what is and is not a valid version identifier for Python packages. Using just the first seven characters of the commit hash, as we were doing, was not compliant. This started causing an increasing number of problems as packages dropped support for non-PEP 440 compliant versions. Having to pin to an older `setuptools` was one of work-arounds we had to do.

Thankfully, prepending a `0+g` to the commit hash is enough to make the version number compliant again. :)

[Note, the `g` is not strictly necessary but apparently is best practice for denoting which version control system (e.g. "g" for Git) was used to make the hash.]